### PR TITLE
Refactor repository update methods to accept domain objects

### DIFF
--- a/DAL/AnnouncementRepository.cs
+++ b/DAL/AnnouncementRepository.cs
@@ -61,32 +61,17 @@ namespace Deer_Hub_Backend.DAL
             return announcements;
         }
 
-        public bool UpdateAnnouncement(int id, string? title = null, string? description = null)
+        public bool UpdateAnnouncement(Announcement announcement)
         {
             try
             {
                 using (var con = DBHelper.GetConnection())
                 {
-                    var updates = new List<string>();
-                    var cmd = new SqlCommand();
-                    cmd.Connection = con;
-
-                    if (title != null)
-                    {
-                        updates.Add("Title = @Title");
-                        cmd.Parameters.AddWithValue("@Title", title);
-                    }
-                    if (description != null)
-                    {
-                        updates.Add("Description = @Description");
-                        cmd.Parameters.AddWithValue("@Description", description);
-                    }
-
-                    if (updates.Count == 0)
-                        return false; // Nothing to update
-
-                    cmd.CommandText = $"UPDATE Announcements SET {string.Join(", ", updates)} WHERE AnnouncementID = @ID";
-                    cmd.Parameters.AddWithValue("@ID", id);
+                    SqlCommand cmd = new SqlCommand("UPDATE Announcements SET Title = @Title, Description = @Description, IsVisible = @IsVisible WHERE AnnouncementID = @AnnouncementID", con);
+                    cmd.Parameters.AddWithValue("@Title", announcement.Title);
+                    cmd.Parameters.AddWithValue("@Description", announcement.Description);
+                    cmd.Parameters.AddWithValue("@IsVisible", announcement.IsVisible);
+                    cmd.Parameters.AddWithValue("@AnnouncementID", announcement.AnnouncementID);
                     con.Open();
                     return cmd.ExecuteNonQuery() > 0;
                 }
@@ -115,6 +100,37 @@ namespace Deer_Hub_Backend.DAL
                 Console.WriteLine("DeleteAnnouncement Error: " + ex.Message);
                 return false;
             }
+        }
+
+        public Announcement GetAnnouncementById(int announcementId)
+        {
+            try
+            {
+                using (var con = DBHelper.GetConnection())
+                {
+                    SqlCommand cmd = new SqlCommand("SELECT * FROM Announcements WHERE AnnouncementID = @AnnouncementID", con);
+                    cmd.Parameters.AddWithValue("@AnnouncementID", announcementId);
+                    con.Open();
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    if (reader.Read())
+                    {
+                        return new Announcement
+                        {
+                            AnnouncementID = (int)reader["AnnouncementID"],
+                            Title = reader["Title"].ToString(),
+                            Description = reader["Description"].ToString(),
+                            PostedBy = (int)reader["PostedBy"],
+                            PostedAt = (DateTime)reader["PostedAt"],
+                            IsVisible = (bool)reader["IsVisible"]
+                        };
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("GetAnnouncementById Error: " + ex.Message);
+            }
+            return null;
         }
     }
 }

--- a/DAL/DepartmentRepository.cs
+++ b/DAL/DepartmentRepository.cs
@@ -55,33 +55,16 @@ namespace Deer_Hub_Backend.DAL
             return departments;
         }
 
-        public bool UpdateDepartment(int id, string? newName, string? newDescription)
+        public bool UpdateDepartment(Department department)
         {
             try
             {
                 using (var con = DBHelper.GetConnection())
                 {
-                    var updates = new List<string>();
-                    var cmd = new SqlCommand();
-                    cmd.Connection = con;
-
-                    if (!string.IsNullOrEmpty(newName))
-                    {
-                        updates.Add("Name = @Name");
-                        cmd.Parameters.AddWithValue("@Name", newName);
-                    }
-                    if (!string.IsNullOrEmpty(newDescription))
-                    {
-                        updates.Add("Description = @Description");
-                        cmd.Parameters.AddWithValue("@Description", newDescription);
-                    }
-
-                    if (updates.Count == 0)
-                        return false; // Nothing to update
-
-                    cmd.CommandText = $"UPDATE Departments SET {string.Join(", ", updates)} WHERE DepartmentID = @ID";
-                    cmd.Parameters.AddWithValue("@ID", id);
-
+                    SqlCommand cmd = new SqlCommand("UPDATE Departments SET Name = @Name, Description = @Description WHERE DepartmentID = @DepartmentID", con);
+                    cmd.Parameters.AddWithValue("@Name", department.Name);
+                    cmd.Parameters.AddWithValue("@Description", department.Description ?? (object)DBNull.Value);
+                    cmd.Parameters.AddWithValue("@DepartmentID", department.DepartmentID);
                     con.Open();
                     return cmd.ExecuteNonQuery() > 0;
                 }
@@ -110,6 +93,34 @@ namespace Deer_Hub_Backend.DAL
                 Console.WriteLine("DeleteDepartment Error: " + ex.Message);
                 return false;
             }
+        }
+
+        public Department GetDepartmentById(int departmentId)
+        {
+            try
+            {
+                using (var con = DBHelper.GetConnection())
+                {
+                    SqlCommand cmd = new SqlCommand("SELECT * FROM Departments WHERE DepartmentID = @DepartmentID", con);
+                    cmd.Parameters.AddWithValue("@DepartmentID", departmentId);
+                    con.Open();
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    if (reader.Read())
+                    {
+                        return new Department
+                        {
+                            DepartmentID = (int)reader["DepartmentID"],
+                            Name = reader["Name"].ToString(),
+                            Description = reader["Description"].ToString()
+                        };
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("GetDepartmentById Error: " + ex.Message);
+            }
+            return null;
         }
     }
 }

--- a/DAL/EmployeeRepository.cs
+++ b/DAL/EmployeeRepository.cs
@@ -70,46 +70,20 @@ namespace Deer_Hub_Backend.DAL
             return employees;
         }
 
-        public bool UpdateEmployee(int employeeId, string? fullName = null, int? departmentId = null, DateTime? dateOfJoining = null, string? phoneNumber = null)
+        public bool UpdateEmployee(Employee emp)
         {
             try
             {
-                var updates = new List<string>();
-                var parameters = new List<SqlParameter>();
-
-                if (fullName != null)
-                {
-                    updates.Add("FullName = @FullName");
-                    parameters.Add(new SqlParameter("@FullName", fullName));
-                }
-                if (departmentId.HasValue)
-                {
-                    updates.Add("DepartmentID = @DepartmentID");
-                    parameters.Add(new SqlParameter("@DepartmentID", departmentId.Value));
-                }
-                if (dateOfJoining.HasValue)
-                {
-                    updates.Add("DateOfJoining = @DateOfJoining");
-                    parameters.Add(new SqlParameter("@DateOfJoining", dateOfJoining.Value));
-                }
-                if (phoneNumber != null)
-                {
-                    updates.Add("PhoneNumber = @PhoneNumber");
-                    parameters.Add(new SqlParameter("@PhoneNumber", phoneNumber));
-                }
-
-                if (updates.Count == 0)
-                    return false; // Nothing to update
-
-                updates.Add("ModifiedAt = GETDATE()");
-
-                string sql = $"UPDATE Employees SET {string.Join(", ", updates)} WHERE EmployeeID = @EmployeeID";
-                parameters.Add(new SqlParameter("@EmployeeID", employeeId));
-
                 using (var con = DBHelper.GetConnection())
                 {
+                    string sql = @"UPDATE Employees SET FullName = @FullName, DepartmentID = @DepartmentID, DateOfJoining = @DateOfJoining, PhoneNumber = @PhoneNumber, IsActive = @IsActive, ModifiedAt = GETDATE() WHERE EmployeeID = @EmployeeID";
                     SqlCommand cmd = new SqlCommand(sql, con);
-                    cmd.Parameters.AddRange(parameters.ToArray());
+                    cmd.Parameters.AddWithValue("@FullName", emp.FullName);
+                    cmd.Parameters.AddWithValue("@DepartmentID", emp.DepartmentID);
+                    cmd.Parameters.AddWithValue("@DateOfJoining", emp.DateOfJoining);
+                    cmd.Parameters.AddWithValue("@PhoneNumber", emp.PhoneNumber ?? (object)DBNull.Value);
+                    cmd.Parameters.AddWithValue("@IsActive", emp.IsActive);
+                    cmd.Parameters.AddWithValue("@EmployeeID", emp.EmployeeID);
                     con.Open();
                     return cmd.ExecuteNonQuery() > 0;
                 }

--- a/DAL/LeaveStatusRepository.cs
+++ b/DAL/LeaveStatusRepository.cs
@@ -53,15 +53,15 @@ namespace DAL
             return statuses;
         }
 
-        public bool UpdateStatus(int id, string statusName)
+        public bool UpdateStatus(LeaveStatus status)
         {
             try
             {
                 using (var con = DBHelper.GetConnection())
                 {
-                    SqlCommand cmd = new SqlCommand("UPDATE LeaveStatuses SET StatusName = @StatusName WHERE StatusID = @ID", con);
-                    cmd.Parameters.AddWithValue("@StatusName", statusName);
-                    cmd.Parameters.AddWithValue("@ID", id);
+                    SqlCommand cmd = new SqlCommand("UPDATE LeaveStatuses SET StatusName = @StatusName WHERE StatusID = @StatusID", con);
+                    cmd.Parameters.AddWithValue("@StatusName", status.StatusName);
+                    cmd.Parameters.AddWithValue("@StatusID", status.StatusID);
                     con.Open();
                     return cmd.ExecuteNonQuery() > 0;
                 }
@@ -90,6 +90,33 @@ namespace DAL
                 Console.WriteLine("DeleteStatus Error: " + ex.Message);
                 return false;
             }
+        }
+
+        public LeaveStatus GetLeaveStatusById(int statusId)
+        {
+            try
+            {
+                using (var con = DBHelper.GetConnection())
+                {
+                    SqlCommand cmd = new SqlCommand("SELECT * FROM LeaveStatuses WHERE StatusID = @StatusID", con);
+                    cmd.Parameters.AddWithValue("@StatusID", statusId);
+                    con.Open();
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    if (reader.Read())
+                    {
+                        return new LeaveStatus
+                        {
+                            StatusID = (int)reader["StatusID"],
+                            StatusName = reader["StatusName"].ToString()
+                        };
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("GetLeaveStatusById Error: " + ex.Message);
+            }
+            return null;
         }
     }
 }

--- a/DAL/LeaveTypeRepository.cs
+++ b/DAL/LeaveTypeRepository.cs
@@ -55,33 +55,16 @@ namespace Deer_Hub_Backend.DAL
             return types;
         }
 
-        public bool UpdateLeaveType(int id, string? name, string? description)
+        public bool UpdateLeaveType(LeaveType leaveType)
         {
             try
             {
                 using (var con = DBHelper.GetConnection())
                 {
-                    var updates = new List<string>();
-                    var cmd = new SqlCommand();
-                    cmd.Connection = con;
-
-                    if (name != null)
-                    {
-                        updates.Add("Name = @Name");
-                        cmd.Parameters.AddWithValue("@Name", name);
-                    }
-                    if (description != null)
-                    {
-                        updates.Add("Description = @Description");
-                        cmd.Parameters.AddWithValue("@Description", description);
-                    }
-
-                    if (updates.Count == 0)
-                        return false; // Nothing to update
-
-                    string updateClause = string.Join(", ", updates);
-                    cmd.CommandText = $"UPDATE LeaveTypes SET {updateClause} WHERE LeaveTypeID = @ID";
-                    cmd.Parameters.AddWithValue("@ID", id);
+                    SqlCommand cmd = new SqlCommand("UPDATE LeaveTypes SET Name = @Name, Description = @Description WHERE LeaveTypeID = @LeaveTypeID", con);
+                    cmd.Parameters.AddWithValue("@Name", leaveType.Name);
+                    cmd.Parameters.AddWithValue("@Description", leaveType.Description ?? (object)DBNull.Value);
+                    cmd.Parameters.AddWithValue("@LeaveTypeID", leaveType.LeaveTypeID);
                     con.Open();
                     return cmd.ExecuteNonQuery() > 0;
                 }
@@ -110,6 +93,34 @@ namespace Deer_Hub_Backend.DAL
                 Console.WriteLine("DeleteLeaveType Error: " + ex.Message);
                 return false;
             }
+        }
+
+        public LeaveType GetLeaveTypeById(int leaveTypeId)
+        {
+            try
+            {
+                using (var con = DBHelper.GetConnection())
+                {
+                    SqlCommand cmd = new SqlCommand("SELECT * FROM LeaveTypes WHERE LeaveTypeID = @LeaveTypeID", con);
+                    cmd.Parameters.AddWithValue("@LeaveTypeID", leaveTypeId);
+                    con.Open();
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    if (reader.Read())
+                    {
+                        return new LeaveType
+                        {
+                            LeaveTypeID = (int)reader["LeaveTypeID"],
+                            Name = reader["Name"].ToString(),
+                            Description = reader["Description"].ToString()
+                        };
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("GetLeaveTypeById Error: " + ex.Message);
+            }
+            return null;
         }
     }
 }

--- a/DAL/UserRepository.cs
+++ b/DAL/UserRepository.cs
@@ -65,52 +65,19 @@ namespace Deer_Hub_Backend.DAL
             return users;
         }
 
-        public bool UpdateUser(int userId, string? username = null, string? email = null, string? passwordHash = null, string? role = null, bool? isActive = null)
+        public bool UpdateUser(User user)
         {
             try
             {
-                var updates = new List<string>();
-                var parameters = new List<SqlParameter>();
-
-                if (username != null)
-                {
-                    updates.Add("Username = @Username");
-                    parameters.Add(new SqlParameter("@Username", username));
-                }
-                if (email != null)
-                {
-                    updates.Add("Email = @Email");
-                    parameters.Add(new SqlParameter("@Email", email));
-                }
-                if (passwordHash != null)
-                {
-                    updates.Add("PasswordHash = @PasswordHash");
-                    parameters.Add(new SqlParameter("@PasswordHash", passwordHash));
-                }
-                if (role != null)
-                {
-                    updates.Add("Role = @Role");
-                    parameters.Add(new SqlParameter("@Role", role));
-                }
-                if (isActive.HasValue)
-                {
-                    updates.Add("IsActive = @IsActive");
-                    parameters.Add(new SqlParameter("@IsActive", isActive.Value));
-                }
-
-                if (updates.Count == 0)
-                    return false; // Nothing to update
-
-                updates.Add("ModifiedAt = GETDATE()");
-
-                var setClause = string.Join(", ", updates);
-                var query = $"UPDATE Users SET {setClause} WHERE UserID = @UserID";
-                parameters.Add(new SqlParameter("@UserID", userId));
-
                 using (var con = DBHelper.GetConnection())
                 {
-                    SqlCommand cmd = new SqlCommand(query, con);
-                    cmd.Parameters.AddRange(parameters.ToArray());
+                    SqlCommand cmd = new SqlCommand("UPDATE Users SET Username = @Username, Email = @Email, PasswordHash = @PasswordHash, Role = @Role, IsActive = @IsActive, ModifiedAt = GETDATE() WHERE UserID = @UserID", con);
+                    cmd.Parameters.AddWithValue("@Username", user.Username);
+                    cmd.Parameters.AddWithValue("@Email", user.Email);
+                    cmd.Parameters.AddWithValue("@PasswordHash", user.PasswordHash);
+                    cmd.Parameters.AddWithValue("@Role", user.Role);
+                    cmd.Parameters.AddWithValue("@IsActive", user.IsActive);
+                    cmd.Parameters.AddWithValue("@UserID", user.UserID);
                     con.Open();
                     return cmd.ExecuteNonQuery() > 0;
                 }
@@ -140,6 +107,39 @@ namespace Deer_Hub_Backend.DAL
                 Console.WriteLine("DeleteUser Error: " + ex.Message);
                 return false;
             }
+        }
+
+        public User GetUserById(int userId)
+        {
+            try
+            {
+                using (var con = DBHelper.GetConnection())
+                {
+                    SqlCommand cmd = new SqlCommand("SELECT * FROM Users WHERE UserID = @UserID", con);
+                    cmd.Parameters.AddWithValue("@UserID", userId);
+                    con.Open();
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    if (reader.Read())
+                    {
+                        return new User
+                        {
+                            UserID = (int)reader["UserID"],
+                            Username = reader["Username"].ToString(),
+                            Email = reader["Email"].ToString(),
+                            PasswordHash = reader["PasswordHash"].ToString(),
+                            Role = reader["Role"].ToString(),
+                            IsActive = (bool)reader["IsActive"],
+                            CreatedAt = (DateTime)reader["CreatedAt"],
+                            ModifiedAt = reader["ModifiedAt"] as DateTime?
+                        };
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("GetUserById Error: " + ex.Message);
+            }
+            return null;
         }
     }
 }

--- a/Services/AnnouncementService.cs
+++ b/Services/AnnouncementService.cs
@@ -23,9 +23,9 @@ namespace Deer_Hub_Backend.Services
             return _repository.GetAllAnnouncements();
         }
 
-        public string UpdateAnnouncement(int id, string? title = null, string? description = null)
+        public string UpdateAnnouncement(Announcement announcement)
         {
-            bool success = _repository.UpdateAnnouncement(id, title, description);
+            bool success = _repository.UpdateAnnouncement(announcement);
             return success ? "Announcement updated successfully." : "No changes made or announcement not found.";
         }
 

--- a/Services/DepartmentService.cs
+++ b/Services/DepartmentService.cs
@@ -27,12 +27,12 @@ namespace Deer_Hub_Backend.Services
             return _repository.GetAllDepartments();
         }
 
-        public string UpdateDepartment(int departmentId, string? newName, string? newDescription)
+        public string UpdateDepartment(Department department)
         {
-            if (string.IsNullOrWhiteSpace(newName) && string.IsNullOrWhiteSpace(newDescription))
-                return "Nothing to update.";
+            if (string.IsNullOrWhiteSpace(department.Name))
+                return "Department name is required.";
 
-            bool success = _repository.UpdateDepartment(departmentId, newName, newDescription);
+            bool success = _repository.UpdateDepartment(department);
             return success ? "Department updated successfully." : "Failed to update department.";
         }
 

--- a/Services/EmployeeService.cs
+++ b/Services/EmployeeService.cs
@@ -34,12 +34,15 @@ namespace Deer_Hub_Backend.Services
             return _repository.GetAllEmployees();
         }
 
-        public string UpdateEmployee(int employeeId, string? fullName = null, int? departmentId = null, DateTime? dateOfJoining = null, string? phoneNumber = null)
+        public string UpdateEmployee(Employee employee)
         {
-            if (fullName == null && departmentId == null && dateOfJoining == null && phoneNumber == null)
-                return "Nothing to update.";
-
-            bool success = _repository.UpdateEmployee(employeeId, fullName, departmentId, dateOfJoining, phoneNumber);
+            if (string.IsNullOrWhiteSpace(employee.FullName))
+                return "Full name is required.";
+            if (employee.DepartmentID <= 0)
+                return "Invalid department ID.";
+            if (employee.DateOfJoining > DateTime.Now)
+                return "Date of joining cannot be in the future.";
+            bool success = _repository.UpdateEmployee(employee);
             return success ? "Employee updated successfully." : "Failed to update employee.";
         }
 

--- a/Services/LeaveStatusService.cs
+++ b/Services/LeaveStatusService.cs
@@ -29,12 +29,11 @@ namespace Deer_Hub_Backend.Services
             return _repository.GetAllStatuses();
         }
 
-        public string UpdateStatus(int id, string statusName)
+        public string UpdateStatus(LeaveStatus status)
         {
-            if (string.IsNullOrWhiteSpace(statusName))
+            if (string.IsNullOrWhiteSpace(status.StatusName))
                 return "Status name cannot be empty.";
-
-            bool updated = _repository.UpdateStatus(id, statusName);
+            bool updated = _repository.UpdateStatus(status);
             return updated ? "Leave status updated successfully." : "Failed to update leave status.";
         }
 

--- a/Services/LeaveTypeService.cs
+++ b/Services/LeaveTypeService.cs
@@ -34,12 +34,11 @@ namespace Deer_Hub_Backend.Services
             return _repository.GetAllLeaveTypes();
         }
 
-        public string UpdateLeaveType(int id, string? name = null, string? description = null)
+        public string UpdateLeaveType(LeaveType leaveType)
         {
-            if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(description))
-                return "Nothing to update.";
-
-            bool updated = _repository.UpdateLeaveType(id, name?.Trim(), description?.Trim());
+            if (string.IsNullOrWhiteSpace(leaveType.Name))
+                return "Leave type name cannot be empty.";
+            bool updated = _repository.UpdateLeaveType(leaveType);
             return updated ? "Leave type updated successfully." : "Failed to update leave type.";
         }
 

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -37,12 +37,11 @@ namespace Deer_Hub_Backend.Services
             return _repository.GetAllUsers();
         }
 
-        public string UpdateUser(int userId, string? username = null, string? email = null, string? passwordHash = null, string? role = null, bool? isActive = null)
+        public string UpdateUser(User user)
         {
-            if (username == null && email == null && passwordHash == null && role == null && isActive == null)
-                return "Nothing to update.";
-
-            bool updated = _repository.UpdateUser(userId, username?.Trim(), email?.Trim(), passwordHash, role?.Trim(), isActive);
+            if (string.IsNullOrWhiteSpace(user.Username) || string.IsNullOrWhiteSpace(user.Email) || string.IsNullOrWhiteSpace(user.PasswordHash) || string.IsNullOrWhiteSpace(user.Role))
+                return "All user fields are required.";
+            bool updated = _repository.UpdateUser(user);
             return updated ? "User updated successfully." : "Failed to update user.";
         }
 

--- a/UI/Screens/AnnouncementScreen.cs
+++ b/UI/Screens/AnnouncementScreen.cs
@@ -44,11 +44,19 @@ namespace Deer_Hub_Backend.UI.Screens
 
                 case 2:
                     int updateId = InputHelper.PromptInt("Announcement ID");
-                    string newTitle = InputHelper.Prompt("New Title (optional)", false);
-                    string newDescription = InputHelper.Prompt("New Description (optional)", false);
-                    string updateResult = service.UpdateAnnouncement(updateId,
-                        string.IsNullOrWhiteSpace(newTitle) ? null : newTitle,
-                        string.IsNullOrWhiteSpace(newDescription) ? null : newDescription);
+                    var repo = new AnnouncementRepository();
+                    var existing = repo.GetAnnouncementById(updateId);
+                    if (existing == null)
+                    {
+                        Console.WriteLine("Announcement not found.");
+                        break;
+                    }
+                    string newTitle = InputHelper.Prompt($"New Title (current: {existing.Title})", false);
+                    string newDescription = InputHelper.Prompt($"New Description (current: {existing.Description})", false);
+                    existing.Title = string.IsNullOrWhiteSpace(newTitle) ? existing.Title : newTitle;
+                    existing.Description = string.IsNullOrWhiteSpace(newDescription) ? existing.Description : newDescription;
+                    existing.IsVisible = InputHelper.PromptBool($"Is Visible (current: {(existing.IsVisible ? "Yes" : "No")})");
+                    string updateResult = service.UpdateAnnouncement(existing);
                     Console.WriteLine(updateResult);
                     break;
 

--- a/UI/Screens/DepartmentScreen.cs
+++ b/UI/Screens/DepartmentScreen.cs
@@ -46,12 +46,18 @@ namespace Deer_Hub_Backend.UI.Screens
 
                 case 2:
                     int updateId = InputHelper.PromptInt("Department ID");
-                    string newName = InputHelper.Prompt("New Name (optional)", false);
-                    string newDescription = InputHelper.Prompt("New Description (optional)", false);
-
-                    string updateResult = service.UpdateDepartment(updateId,
-                        string.IsNullOrWhiteSpace(newName) ? null : newName,
-                        string.IsNullOrWhiteSpace(newDescription) ? null : newDescription);
+                    var repo = new DepartmentRepository();
+                    var existing = repo.GetDepartmentById(updateId);
+                    if (existing == null)
+                    {
+                        Console.WriteLine("Department not found.");
+                        break;
+                    }
+                    string newName = InputHelper.Prompt($"New Name (current: {existing.Name})", false);
+                    string newDescription = InputHelper.Prompt($"New Description (current: {existing.Description})", false);
+                    existing.Name = string.IsNullOrWhiteSpace(newName) ? existing.Name : newName;
+                    existing.Description = string.IsNullOrWhiteSpace(newDescription) ? existing.Description : newDescription;
+                    string updateResult = service.UpdateDepartment(existing);
                     Console.WriteLine(updateResult);
                     break;
 

--- a/UI/Screens/EmployeeScreen.cs
+++ b/UI/Screens/EmployeeScreen.cs
@@ -64,24 +64,23 @@ namespace Deer_Hub_Backend.UI.Screens
 
                 case 2:
                     int updateId = InputHelper.PromptInt("Employee ID");
-                    string newFullName = InputHelper.Prompt("New Full Name (optional)", false);
-                    string deptInput = InputHelper.Prompt("New Department ID (optional)", false);
-                    string dateInput = InputHelper.Prompt("New Date of Joining (optional)", false);
-                    string newPhoneNumber = InputHelper.Prompt("New Phone Number (optional)", false);
-
-                    int? newDeptId = null;
-                    if (int.TryParse(deptInput, out int parsedDeptId))
-                        newDeptId = parsedDeptId;
-
-                    DateTime? newDateOfJoining = null;
-                    if (DateTime.TryParse(dateInput, out DateTime parsedDate))
-                        newDateOfJoining = parsedDate;
-
-                    string updateResult = service.UpdateEmployee(updateId,
-                        string.IsNullOrWhiteSpace(newFullName) ? null : newFullName,
-                        newDeptId,
-                        newDateOfJoining,
-                        string.IsNullOrWhiteSpace(newPhoneNumber) ? null : newPhoneNumber);
+                    var repo = new EmployeeRepository();
+                    var existing = repo.GetEmployeeById(updateId);
+                    if (existing == null)
+                    {
+                        Console.WriteLine("Employee not found.");
+                        break;
+                    }
+                    string newFullName = InputHelper.Prompt($"New Full Name (current: {existing.FullName})", false);
+                    string deptInput = InputHelper.Prompt($"New Department ID (current: {existing.DepartmentID})", false);
+                    string dateInput = InputHelper.Prompt($"New Date of Joining (current: {existing.DateOfJoining:yyyy-MM-dd})", false);
+                    string newPhoneNumber = InputHelper.Prompt($"New Phone Number (current: {existing.PhoneNumber})", false);
+                    if (!string.IsNullOrWhiteSpace(newFullName)) existing.FullName = newFullName;
+                    if (int.TryParse(deptInput, out int parsedDeptId)) existing.DepartmentID = parsedDeptId;
+                    if (DateTime.TryParse(dateInput, out DateTime parsedDate)) existing.DateOfJoining = parsedDate;
+                    if (!string.IsNullOrWhiteSpace(newPhoneNumber)) existing.PhoneNumber = newPhoneNumber;
+                    existing.IsActive = InputHelper.PromptBool($"Is Active (current: {(existing.IsActive ? "Yes" : "No")})");
+                    string updateResult = service.UpdateEmployee(existing);
                     Console.WriteLine(updateResult);
                     break;
 

--- a/UI/Screens/LeaveStatusScreen.cs
+++ b/UI/Screens/LeaveStatusScreen.cs
@@ -39,8 +39,16 @@ namespace Deer_Hub_Backend.UI.Screens
 
                 case 2:
                     int updateId = InputHelper.PromptInt("Leave status ID to update");
-                    string newName = InputHelper.Prompt("New status name");
-                    string updateResult = service.UpdateStatus(updateId, newName);
+                    var repo = new LeaveStatusRepository();
+                    var existing = repo.GetLeaveStatusById(updateId);
+                    if (existing == null)
+                    {
+                        Console.WriteLine("Leave status not found.");
+                        break;
+                    }
+                    string newName = InputHelper.Prompt($"New status name (current: {existing.StatusName})");
+                    existing.StatusName = string.IsNullOrWhiteSpace(newName) ? existing.StatusName : newName;
+                    string updateResult = service.UpdateStatus(existing);
                     Console.WriteLine(updateResult);
                     break;
 

--- a/UI/Screens/LeaveTypeScreen.cs
+++ b/UI/Screens/LeaveTypeScreen.cs
@@ -39,9 +39,18 @@ namespace Deer_Hub_Backend.UI.Screens
 
                 case 2:
                     int updateId = InputHelper.PromptInt("Leave type ID to update");
-                    string newName = InputHelper.Prompt("New name (optional)", false);
-                    string newDesc = InputHelper.Prompt("New description (optional)", false);
-                    string updateResult = service.UpdateLeaveType(updateId, newName, newDesc);
+                    var repo = new LeaveTypeRepository();
+                    var existing = repo.GetLeaveTypeById(updateId);
+                    if (existing == null)
+                    {
+                        Console.WriteLine("Leave type not found.");
+                        break;
+                    }
+                    string newName = InputHelper.Prompt($"New name (current: {existing.Name})", false);
+                    string newDesc = InputHelper.Prompt($"New description (current: {existing.Description})", false);
+                    existing.Name = string.IsNullOrWhiteSpace(newName) ? existing.Name : newName;
+                    existing.Description = string.IsNullOrWhiteSpace(newDesc) ? existing.Description : newDesc;
+                    string updateResult = service.UpdateLeaveType(existing);
                     Console.WriteLine(updateResult);
                     break;
 

--- a/UI/Screens/UserScreen.cs
+++ b/UI/Screens/UserScreen.cs
@@ -39,11 +39,23 @@ namespace Deer_Hub_Backend.UI.Screens
 
                 case 2:
                     int id = InputHelper.PromptInt("User ID");
-                    string newUsername = InputHelper.Prompt("New Username (optional)", false);
-                    string newEmail = InputHelper.Prompt("New Email (optional)", false);
-                    string newRole = InputHelper.Prompt("New Role (optional)", false);
-                    bool isActive = InputHelper.PromptBool("Is Active");
-                    string updateResult = service.UpdateUser(id, newUsername, newEmail, null, newRole, isActive);
+                    var repo = new DAL.UserRepository();
+                    var existing = repo.GetUserById(id);
+                    if (existing == null)
+                    {
+                        Console.WriteLine("User not found.");
+                        break;
+                    }
+                    string newUsername = InputHelper.Prompt($"New Username (current: {existing.Username})", false);
+                    string newEmail = InputHelper.Prompt($"New Email (current: {existing.Email})", false);
+                    string newPassword = InputHelper.Prompt($"New Password Hash (current: {existing.PasswordHash})", false);
+                    string newRole = InputHelper.Prompt($"New Role (current: {existing.Role})", false);
+                    existing.Username = string.IsNullOrWhiteSpace(newUsername) ? existing.Username : newUsername;
+                    existing.Email = string.IsNullOrWhiteSpace(newEmail) ? existing.Email : newEmail;
+                    existing.PasswordHash = string.IsNullOrWhiteSpace(newPassword) ? existing.PasswordHash : newPassword;
+                    existing.Role = string.IsNullOrWhiteSpace(newRole) ? existing.Role : newRole;
+                    existing.IsActive = InputHelper.PromptBool($"Is Active (current: {(existing.IsActive ? "Yes" : "No")})");
+                    string updateResult = service.UpdateUser(existing);
                     Console.WriteLine(updateResult);
                     break;
 


### PR DESCRIPTION
- Updated `UpdateAnnouncement`, `UpdateDepartment`, `UpdateEmployee`, `UpdateLeaveType`, `UpdateStatus`, and `UpdateUser` methods in their respective repositories to accept domain objects instead of individual parameters.
- Added new `GetAnnouncementById`, `GetDepartmentById`, `GetEmployeeById`, `GetLeaveStatusById`, `GetLeaveTypeById`, and `GetUserById` methods to retrieve entities by ID.
- Enhanced service methods to accommodate the new repository method signatures, improving code clarity and maintainability.